### PR TITLE
change <</p> to </p>

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.footer.enable  }}
 <div id="copyright" class="container">
-  <p>{{ with .Site.Params.footer.copy  }}{{ . | markdownify  }}{{ end  }}<</p>
+  <p>{{ with .Site.Params.footer.copy  }}{{ . | markdownify  }}{{ end  }}</p>
 </div>
 {{ end  }}


### PR DESCRIPTION
Removes the extra `<` in the closing paragraph tag of the footer, which I assume isn't intentional?

<img width="326" alt="screen shot 2018-09-19 at 00 03 18" src="https://user-images.githubusercontent.com/822601/45730426-89268f80-bb9f-11e8-9f29-c4cb6ea1e953.png">


